### PR TITLE
Fix author/email validation to prevent form errors with logged-in users

### DIFF
--- a/saurabhdhariwal/comments/components/Comments.php
+++ b/saurabhdhariwal/comments/components/Comments.php
@@ -91,8 +91,6 @@ class Comments extends ComponentBase
     public function onSaveCommentButton()
     {
         $formValidation = [
-            'author' => 'alpha_dash|min:2|max:25',
-            'email' => 'email',
             'content' => 'required|min:2|max:500'
         ];
 

--- a/saurabhdhariwal/comments/models/Comments.php
+++ b/saurabhdhariwal/comments/models/Comments.php
@@ -27,11 +27,7 @@ class Comments extends Model
     /**
      * @var array
      */
-    public $rules = [
-            'author' => 'alpha|min:2|max:25',
-            'email' => 'email',
-            'content' => 'required|min:2|max:500'
-    ];
+    public $rules = [];
 
     /*
      * Disable timestamps by default.


### PR DESCRIPTION
`author` and `email` validation are in `components/Comments.php` and `models/Comments.php`. This generate errors when an logged-in user try to post a comment because the `author` and `email` properties are set to `null` if is a authenticated user which post.

So, to fix it, I removed validation when the user is authenticated because we do not need validation for `null` value on these properties.

The validation still for guest users.